### PR TITLE
from legacy react to modern react using hooks

### DIFF
--- a/src/containers/shell/ChatShell.js
+++ b/src/containers/shell/ChatShell.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { conversationChanged, newMessageAdded, conversationDeleted, conversationsRequested } from '../../store/actions';
 import ConversationSearch from '../../components/conversation/conversation-search/ConversationSearch';
@@ -12,17 +12,18 @@ import ChatForm from '../../components/chat-form/ChatForm';
 
 import './ChatShell.scss';
 
-const ChatShell = ({ 
-    conversations, 
-    selectedConversation, 
-    conversationChanged,
-    onMessageSubmitted,
-    onDeleteConversation,
-    loadConversations
-}) => {
+const ChatShell = () => {
+    const conversations = useSelector(state => state.conversationState.conversations);
+    const selectedConversation = useSelector(state => state.conversationState.selectedConversation);
+    const dispatch = useDispatch();
+    const onConversationChanged = conversationId => {dispatch(conversationChanged(conversationId))};
+    const onMessageSubmitted = messageText => { dispatch(newMessageAdded(messageText)); };
+    const onDeleteConversation = () => { dispatch(conversationDeleted()); };
+    const loadConversations = () =>  dispatch(conversationsRequested());
+
     useEffect(() => {
         loadConversations();
-    }, [loadConversations]);
+    }, []);
 
     let conversationContent = (
         <>
@@ -42,7 +43,7 @@ const ChatShell = ({
         <div id="chat-container">
             <ConversationSearch conversations={conversations} />
             <ConversationList
-                onConversationItemSelected={conversationChanged}
+                onConversationItemSelected={onConversationChanged}
                 conversations={conversations}
                 selectedConversation={selectedConversation} />
             <NewConversation />
@@ -57,21 +58,5 @@ const ChatShell = ({
     );
 }
 
-const mapStateToProps = state => {
-    return {
-        conversations: state.conversationState.conversations,
-        selectedConversation: state.conversationState.selectedConversation
-    };
-};
-  
-const mapDispatchToProps = dispatch => ({
-    conversationChanged: conversationId => dispatch(conversationChanged(conversationId)),
-    onMessageSubmitted: messageText => { dispatch(newMessageAdded(messageText)); },
-    onDeleteConversation: () => { dispatch(conversationDeleted()); },
-    loadConversations: () => { dispatch(conversationsRequested())}
-});
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(ChatShell);
+export default ChatShell;


### PR DESCRIPTION
Using hooks (useSelector, useDispatch) instead of connect.
support for redux 'connect' will end soon in coming updates.
renamed conversationChanged to onConversationChanged for compliance with the naming conventions for events